### PR TITLE
Fix #22 : Raise an exception when there are duplicates in links

### DIFF
--- a/ipysankeywidget/sankey_widget.py
+++ b/ipysankeywidget/sankey_widget.py
@@ -51,7 +51,11 @@ class SankeyWidget(widgets.DOMWidget):
                 linktype = link['type']
             else:
                 linktype = None
-            values.append((linksource, linktarget, linktype))
+            if 'color' in link:
+                linkcolor = link['color']
+            else:
+                linkcolor = None
+            values.append((linksource, linktarget, linktype, linkcolor))
         if len(values) != len(set(values)):
             raise ValueError("Links have duplicates")
 

--- a/ipysankeywidget/sankey_widget.py
+++ b/ipysankeywidget/sankey_widget.py
@@ -42,6 +42,19 @@ class SankeyWidget(widgets.DOMWidget):
     def __init__(self, **kwargs):
         """Constructor"""
 
+        # check for duplicates in links
+        values = []
+        for link in kwargs.get('links', []):
+            linksource = link['source']
+            linktarget = link['target']
+            if 'type' in link:
+                linktype = link['type']
+            else:
+                linktype = None
+            values.append((linksource, linktarget, linktype))
+        if len(values) != len(set(values)):
+            raise ValueError("Links have duplicates")
+
         # Automatically create nodes
         nodes = kwargs.get('nodes', [])
         node_ids = {node['id'] for node in nodes}


### PR DESCRIPTION
I checked for the following keywords:

- source
- target
- type
- color

I don't think there are others that should be checked.

I checked that the examples in the repo still worrked after this commit.